### PR TITLE
add .hugo_build.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 resources/
+.hugo_build.lock


### PR DESCRIPTION
it was added in version 0.89.0
https://discourse.gohugo.io/t/what-is-the-hugo-build-lock-file/35417